### PR TITLE
Add developer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@ This project provides organized data about the contents of a library.
 
 ##### Project Status
 
-Alpha released. 
+Alpha released.
 
+
+##### Getting Started
+1. fork and clone this repository
+2. create and activate a [virtualenv] (https://virtualenv.pypa.io)
+3. pip install -r requirements.txt
+4. cd static && npm install && gulp
+5. python controller.py
+6. go to localhost:5000 in the browser
 
 
 ##### Features on-deck:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Alpha released.
 1. fork and clone this repository
 2. [create] (https://virtualenvwrapper.readthedocs.org) and activate a [virtualenv] (https://virtualenv.pypa.io)
 3. pip install -r requirements.txt
-4. cd static && npm install && gulp
+4. cd [static] (https://github.com/robbintt/library-org/blob/master/static/README.md) && npm install && gulp
 5. python controller.py
 6. go to [localhost:5000] (http://localhost:5000) in the browser
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Alpha released.
 
 ##### Getting Started
 1. fork and clone this repository
-2. create and activate a [virtualenv] (https://virtualenv.pypa.io)
+2. [create] (https://virtualenvwrapper.readthedocs.org) and activate a [virtualenv] (https://virtualenv.pypa.io)
 3. pip install -r requirements.txt
 4. cd static && npm install && gulp
 5. python controller.py
-6. go to localhost:5000 in the browser
+6. go to [localhost:5000] (http://localhost:5000) in the browser
 
 
 ##### Features on-deck:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Alpha released.
 1. fork and clone this repository
 2. [create] (https://virtualenvwrapper.readthedocs.org) and activate a [virtualenv] (https://virtualenv.pypa.io)
 3. pip install -r requirements.txt
-4. cd [static] (https://github.com/robbintt/library-org/blob/master/static/README.md) && npm install && gulp
+4. cd [static] (static/README.md) && npm install && gulp
 5. python controller.py
 6. go to [localhost:5000] (http://localhost:5000) in the browser
 

--- a/static/README.md
+++ b/static/README.md
@@ -2,17 +2,24 @@
 ## TODO:
 Looks like there isn't any default css minifier. Add one! See sage/roots gulpfile.
 
-## Status:
-Bower has been installed, gulp has been installed.  Dependencies are now kept in source control.
+## Dependencies:
+1. NodeJS
+2. Bower
+3. Gulp
+
+## Instructions
 In order to unpack this project in a new space:
-    1. install npm, gulp, bower.
-    2. gulp has dependencies in gulpfile.js, bower has dependencies in bower.json.
-    3. Put your assets in the src folder.
-    4. node_modules, dist (compiled destination of src files), and bower_components are not kept under source control. These can be rebuilt by installing each. dist is built by running 'gulp'
+1. install NodeJS (on OS X: `brew install node`)
+2. npm install -g bower gulp
+3. npm install
+4. bower install
+5. gulp
+Put your assets in the src folder.
+The directories `node_modules`, `dist` (compiled destination of src files), and `bower_components` are not kept under source control. These can be rebuilt by installing each. `dist` is built by running 'gulp'
 
 ## Notes:
 This git repository is very conservative, only ignoring the following: node_modules.
-The purpose of this is to allow particular projects 
+The purpose of this is to allow particular projects
 A bower init has already been completed. This may need revisited.
 
 There are options in gulpfule.js to make the bower command install or update.

--- a/static/README.md
+++ b/static/README.md
@@ -9,11 +9,13 @@ Looks like there isn't any default css minifier. Add one! See sage/roots gulpfil
 
 ## Instructions
 In order to unpack this project in a new space:
+
 1. install NodeJS (on OS X: `brew install node`)
 2. npm install -g bower gulp
 3. npm install
 4. bower install
 5. gulp
+
 Put your assets in the src folder.
 The directories `node_modules`, `dist` (compiled destination of src files), and `bower_components` are not kept under source control. These can be rebuilt by installing each. `dist` is built by running 'gulp'
 


### PR DESCRIPTION
This PR aims to address #3 

Having the instructions at the root of the repository increases its visibility.
Future improvements can link to the `static/README.md` file that holds more specific javascript instructions.
