### PR TITLE
Enable dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  # Note, the file `runtime.txt` is used to hint to dependabot
+  # the minimum version requirement for updates.
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    labels:
+      - "dependencies"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Make sure this matches runtime.txt
 FROM python:3.13
 
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,0 +1,3 @@
+python-3.13
+# Specifies the python version that dependabot should use.
+# Make sure this matches the Dockerfile.


### PR DESCRIPTION
Add configuration for dependabot.
* Add a runtime.txt to hint to Dependabot what Python version is used.